### PR TITLE
Made the reloadCSS functionality available in the context menu.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CSS Reload
 
-Reload the linked CSS stylesheets in the current page using Ctrl+F9 or page action.
+Reload the linked CSS stylesheets in the current page using Ctrl+F9, context menu or page action.
 
 If you want to omit some style sheet from reloading (i.e. font foundry resources) add attribute "data-autoreload" with value "false" like this:
 <blockquote><code>&lt;link href="" rel="stylesheet" type="text/css" <strong>data-autoreload="false"</strong>&gt;</code></blockquote>

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -6,5 +6,9 @@
   "page_action_title": {
     "message": "Reloads the stylesheets",
     "description": "Action button title."
+  },
+  "context_menu_title": {
+    "message": "Reload the stylesheets",
+    "description": "Context menu title."
   }
 }

--- a/background.js
+++ b/background.js
@@ -18,13 +18,30 @@ browser.tabs.onUpdated.addListener((tabId, changed) => {
 })
 
 browser.pageAction.onClicked.addListener((tab) => {
-  browser.tabs.executeScript(tab.id, {
+  executeReloadCssScript(tab.id)
+})
+
+browser.contextMenus.create({
+  id: "reloadCss",
+  title: "Reloads the stylesheets",
+  title: browser.i18n.getMessage("context_menu_title"),
+  contexts: ["page"]
+})
+
+browser.contextMenus.onClicked.addListener(function(info, tab) {
+  if (info.menuItemId === "reloadCss"){
+    executeReloadCssScript(tab.id)
+  }
+})
+
+function executeReloadCssScript(tabId)
+{
+  browser.tabs.executeScript(tabId, {
     file: 'assets/css-reload.js'
   }).catch(err => {
     // mute permission errors
   })
-})
-
+}
 
 function activateAction(tabId)
 {

--- a/manifest.json
+++ b/manifest.json
@@ -29,7 +29,7 @@
     }
   },
 
-  "permissions": ["activeTab"],
+  "permissions": ["activeTab", "contextMenus"],
 
   "default_locale": "en"
 }


### PR DESCRIPTION
I was really missing the option to reload the CSS from the context menu. 
It was a feature of https://addons.mozilla.org/nl/firefox/addon/css-reloader/ which i used until recently, but isn't supported anymore.